### PR TITLE
Error no such option: -I

### DIFF
--- a/src/Youtubedl/Youtubedl.php
+++ b/src/Youtubedl/Youtubedl.php
@@ -84,7 +84,7 @@ class Youtubedl
         $option.="{$this->video} {$this->verbosity} ";
         $option.="{$this->postProcessing}";
         $option.="{$this->option}";
-        $process=new Process("youtube-dl {$option} {$cmd}");
+        $process=new Process("youtube-dl {$option} -- {$cmd}");
         if ($this->verbose) {
             $process->run(function ($type,$buffer) {
                 if (Process::ERR === $type) {


### PR DESCRIPTION
I was getting this error as the video ID I was trying to download started with a - character.

As per https://github.com/rg3/youtube-dl#how-do-i-download-a-video-starting-with-a--- putting -- between the options and the video ID resolves this.
